### PR TITLE
Optimize the rust solution via use of `.lines`

### DIFF
--- a/Rust/src/solutions/day_01.rs
+++ b/Rust/src/solutions/day_01.rs
@@ -2,7 +2,7 @@ use crate::into_answers::IntoAnswers;
 
 #[rustfmt::skip]
 pub fn solution(input: String) -> impl IntoAnswers {
-    // Solution score:     151 vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-    let solution = |i: String| {let mut y:Vec<i32>=i.split("\n\n").map(|g|g.split('\n').map(|i|->i32{i.parse().unwrap()}).sum()).collect();y.sort_by_key(|y|-y);(y[0],y[0]+y[1]+y[2])};
+    // Solution score:     147 vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+    let solution = |i: String| {let mut y:Vec<i32>=i.split("\n\n").map(|g|g.lines().map(|x|x.parse::<i32>().unwrap()).sum()).collect();y.sort_by_key(|y|-y);(y[0],y[0]+y[1]+y[2])};
     solution(input)
 }


### PR DESCRIPTION
Wasn't sure if I should edit or create a new file, but ended up just editing.

`.lines()` is shorter than `.split("\n")`, so I just used that :P