### PR TITLE
Optimize Python, Day 2, 117 -> 114 -> 99

### DIFF
--- a/Python/day_02/__init__.py
+++ b/Python/day_02/__init__.py
@@ -1,1 +1,1 @@
-from . import starwort_02
+from . import starwort_03

--- a/Python/day_02/starwort_03.py
+++ b/Python/day_02/starwort_03.py
@@ -1,0 +1,3 @@
+# 99
+# fmt: off
+print(*[sum(s)for s in zip(*((3*((r-o+2)%3)+r-87,3*r+(r+o+2)%3-263)for o,_,r,*_ in open(0,'rb')))])

--- a/Python/day_02/taesungh_02.py
+++ b/Python/day_02/taesungh_02.py
@@ -1,0 +1,3 @@
+# 114
+# fmt: off
+print(*[sum(s)for s in zip(*((3*((r-o+2)%3)+r-87,3*r+(r+o+2)%3-263)for l in open(0)for o,_,r,*_ in[map(ord,l)]))])


### PR DESCRIPTION
Originally solution broke during reorganization in 844bfd5 because the input files don't have a final newline character, but discovered a workaround with unpacking.